### PR TITLE
Verify scraping on VM-side in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
         command: bash -i ~/setup-vm.sh $CIRCLE_SHA1
 
     - run:
+        name: Copy a freeware ROM to VM
+        command: bash -i ~/ssh-vm.sh "sudo wget -P retro-cloud-share/RetroPie/roms/scummvm/ -nv https://www.scummvm.org/frs/extras/Mystery%20House/MYSTHOUS.zip"
+
+    - run:
         name: Run scraper on VM
         command: bash -i ~/run-scraper.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     docker:
     - image: seriema/retro-cloud:develop
     shell: /bin/bash --login -eo pipefail
+    working_directory: /home/pi
     steps:
 
     - run:
@@ -28,15 +29,15 @@ jobs:
 
     - run:
         name: Install Retro-Cloud on VM
-        command: bash -i ~/setup-vm.sh $CIRCLE_SHA1
+        command: bash -i setup-vm.sh $CIRCLE_SHA1
 
     - run:
         name: Copy a freeware ROM to VM
-        command: bash -i ~/ssh-vm.sh "sudo wget -P retro-cloud-share/RetroPie/roms/scummvm/ -nv https://www.scummvm.org/frs/extras/Mystery%20House/MYSTHOUS.zip"
+        command: bash -i ssh-vm.sh "sudo wget -P retro-cloud-share/RetroPie/roms/scummvm/ -nv https://www.scummvm.org/frs/extras/Mystery%20House/MYSTHOUS.zip"
 
     - run:
         name: Run scraper on VM
-        command: bash -i ~/run-scraper.sh
+        command: bash -i run-scraper.sh
 
     - run:
         name: Teardown Azure resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
 
     - run:
         name: Copy a freeware ROM to VM
-        command: bash -i ssh-vm.sh "sudo wget -P retro-cloud-share/RetroPie/roms/scummvm/ -nv https://www.scummvm.org/frs/extras/Mystery%20House/MYSTHOUS.zip"
+        command: bash -i ssh-vm.sh "wget -O - -nv https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-copy-rom.sh | bash -i"
 
     - run:
         name: Run scraper on VM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,20 @@ jobs:
         command: bash -i run-scraper.sh
 
     - run:
+        name: Print RaspberryPi ~/ directory listing
+        command: sudo find ~ | sed -e "s/[^-][^\/]*\// |/g" -e "s/|\([^ ]\)/|-\1/"
+        when: always
+
+    - run:
+        name: Print VM ~/ directory listing
+        command: |
+            printCmd='sudo find ~ | sed -e "s/[^-][^\/]*\// |/g" -e "s/|\([^ ]\)/|-\1/"'
+            echo 'ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP' "'$printCmd'" > print-vm-filesystem.sh
+            bash -i print-vm-filesystem.sh
+            rm print-vm-filesystem.sh
+        when: always
+
+    - run:
         name: Teardown Azure resources
         command: |
             wget -nv "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/teardown.sh"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
         command: bash -i ~/setup-vm.sh $CIRCLE_SHA1
 
     - run:
+        name: Run scraper on VM
+        command: bash -i ~/run-scraper.sh
+
+    - run:
         name: Teardown Azure resources
         command: |
             wget -nv "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/teardown.sh"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,14 @@ jobs:
         when: always
 
     - run:
+        name: Verify scraper output on VM
+        command: |
+            bash -i ssh-vm.sh "wget -P ~/tmp -nv https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist.sh"
+            bash -i ssh-vm.sh "wget -P ~/tmp -nv https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist.xml"
+            bash -i ssh-vm.sh "bash -i ~/tmp/test-gamelist.sh"
+            bash -i ssh-vm.sh "rm ~/tmp/test-gamelist.sh ~/tmp/test-gamelist.xml"
+
+    - run:
         name: Teardown Azure resources
         command: |
             wget -nv "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/teardown.sh"

--- a/raspberry-pi/local/run-scraper.sh
+++ b/raspberry-pi/local/run-scraper.sh
@@ -5,6 +5,4 @@ set -e
 # Error if variable is unset
 set -u
 
-# There's a "permission denied" response when sending "./run-skyscraper.sh"
-ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP "./run-skyscraper.sh"
-# ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP "bash -i run-skyscraper.sh"
+bash -i ssh-vm.sh "./run-skyscraper.sh"

--- a/raspberry-pi/local/setup-vm.sh
+++ b/raspberry-pi/local/setup-vm.sh
@@ -5,6 +5,6 @@ branch=${1:-develop}
 # Abort on error, and error if variable is unset
 set -eu
 
-ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP "wget -nv https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/setup.sh"
-ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP "bash -i setup.sh $branch"
-ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP "rm setup.sh"
+bash -i ssh-vm.sh "wget -nv https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/setup.sh"
+bash -i ssh-vm.sh "bash -i setup.sh $branch"
+bash -i ssh-vm.sh "rm setup.sh"

--- a/raspberry-pi/local/ssh-vm.sh
+++ b/raspberry-pi/local/ssh-vm.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -i
+# Script takes optional parameter for a command to send to the VM.
+vmCmd=${1:-""}
 
 # Abort on error
 set -e
 # Error if variable is unset
 set -u
 
-ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP
+ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP $vmCmd

--- a/virtual-machine/dev/test-copy-rom.sh
+++ b/virtual-machine/dev/test-copy-rom.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Abort on error, and error if variable is unset
+set -eu
+
+# Copy a tiny (58K) freeware game from a verified list on ScummVM
+sudo wget -P "$RETROCLOUD_VM_SHARE/RetroPie/roms/scummvm/" -nv https://www.scummvm.org/frs/extras/Mystery%20House/MYSTHOUS.zip
+# Give it a better name otherwise the scrapers don't find it
+mv "$RETROCLOUD_VM_SHARE/RetroPie/roms/scummvm/MYSTHOUS.zip" "$RETROCLOUD_VM_SHARE/RetroPie/roms/scummvm/MysteryHouse.zip"

--- a/virtual-machine/dev/test-gamelist.sh
+++ b/virtual-machine/dev/test-gamelist.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Abort on error, and error if variable is unset
+set -eu
+
+if diff "$RETROCLOUD_VM_SHARE/.emulationstation/gamelists/scummvm/gamelist.xml" ~/tmp/test-gamelist.xml
+then
+    echo "Scraping was successful"
+else
+    echo "Scraping failed somehow because the gamelist isn't as expected. See details above."
+fi

--- a/virtual-machine/dev/test-gamelist.xml
+++ b/virtual-machine/dev/test-gamelist.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<gameList>
+  <game>
+    <path>/home/pi/RetroPie/roms/scummvm/MysteryHouse.zip</path>
+    <name>Mystery House</name>
+    <cover />
+    <image>/home/pi/.emulationstation/downloaded_media/scummvm/screenshots/MysteryHouse.png</image>
+    <marquee />
+    <video />
+    <rating />
+    <desc>Mystery House is a monochrome interactive fiction adventure game that places the player in a Victorian mansion with seven other people. As the player explores the mansion, he discovers that there is a killer murdering each guest one by one. The objective of the game is to figure out who the murderer is before the murderer finds the hero. Players explore and manipulate objects by typing in one or two-word phrases such as &quot;north&quot; or &quot;get knife&quot;.</desc>
+    <releasedate />
+    <developer>On-Line Systems</developer>
+    <publisher>On-Line Systems</publisher>
+    <genre>Adventure</genre>
+    <players />
+  </game>
+</gameList>

--- a/virtual-machine/local/run-skyscraper.sh
+++ b/virtual-machine/local/run-skyscraper.sh
@@ -111,18 +111,18 @@ do
 
     # "arcadedb" only has MAME games
     if [[ $platform == *"mame"* ]]; then
-        Skyscraper -p $platform -s 'arcadedb' > /dev/null
+        Skyscraper -p $platform -s 'arcadedb'
     fi
 
     # TODO: If there are no games found, run the "screenscraper" module again but with the --unpack flag?
 
     for module in "${modules[@]}"
     do
-        Skyscraper -p $platform -s $module > /dev/null
+        Skyscraper -p $platform -s $module
     done
 
     echo "Generating gamelists and artwork for $platform"
-    Skyscraper -p $platform > /dev/null
+    Skyscraper -p $platform
 
     # This step is needed because the AZ mounted path is reflected in the gamelists, and they're symlinked on the rpi to look local.
     echo "Fixing paths in gamelists for $platform"


### PR DESCRIPTION
Run the scraper on the VM and verify that it works. It downloads [the freeware game Mystery House](https://www.scummvm.org/games/#mysthous) for testing.

Known limitation: Mounting the VM on the RPi is not possible on the container running in CircleCI, so the game is downloaded by the VM from the Internet instead of the expected scenario where the RPi puts it the ROMs folder and the VM can read it.

This PR is just for convenience in the future to see what had to change in the scripts to support the merged feature.