### PR TITLE
Validate Azure File Share connection on VM-side in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,15 @@ jobs:
         when: always
 
     - run:
+        name: Print Azure File Share directory listing
+        command: |
+            wget -nv "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/dev/list-az-share.ps1"
+            echo 'pwsh -executionpolicy bypass -File ".\list-az-share.ps1"' > run-az-listing.sh
+            bash -i run-az-listing.sh
+            rm run-az-listing.sh list-az-share.ps1
+        when: always
+
+    - run:
         name: Verify scraper output on VM
         command: |
             bash -i ssh-vm.sh "wget -P ~/tmp -nv https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist.sh"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,14 @@ jobs:
         when: always
 
     - run:
+        name: Verify that ROM shows up in Azure File Share
+        command: |
+            wget -nv "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/dev/test-az-share.ps1"
+            echo 'pwsh -executionpolicy bypass -File ".\test-az-share.ps1"' > run-az-share-test.sh
+            bash -i run-az-share-test.sh
+            rm run-az-share-test.sh test-az-share.ps1
+
+    - run:
         name: Verify scraper output on VM
         command: |
             bash -i ssh-vm.sh "wget -P ~/tmp -nv https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist.sh"

--- a/raspberry-pi/dev/list-az-share.ps1
+++ b/raspberry-pi/dev/list-az-share.ps1
@@ -1,0 +1,22 @@
+# Abort on error
+$ErrorActionPreference = "Stop"
+
+Function GetFiles($parent)
+{
+    $cloud = $parent | Get-AzStorageFile
+    $directories = $cloud | Where-Object {$_.GetType().Name -eq "CloudFileDirectory"}
+    $files = $cloud | Where-Object {$_.GetType().Name -eq "CloudFile"}
+
+    foreach ($directory in $directories) {
+        GetFiles($directory)
+    }
+
+    foreach ($file in $files) {
+        $file.Uri.LocalPath
+    }
+}
+
+$ctx = New-AzStorageContext -StorageAccountName $env:RETROCLOUD_AZ_STORAGE_ACCOUNT_NAME -StorageAccountKey $env:RETROCLOUD_AZ_STORAGE_ACCOUNT_KEY
+$root = Get-AzStorageFile -Context $ctx -ShareName $env:RETROCLOUD_AZ_FILE_SHARE_NAME
+
+GetFiles($root)

--- a/raspberry-pi/dev/test-az-share.ps1
+++ b/raspberry-pi/dev/test-az-share.ps1
@@ -1,0 +1,19 @@
+# Verify that the ROM from test-copy-rom.sh shows up in the Azure File Share.
+
+# Abort on error
+$ErrorActionPreference = "Stop"
+
+$ctx = New-AzStorageContext -StorageAccountName $env:RETROCLOUD_AZ_STORAGE_ACCOUNT_NAME -StorageAccountKey $env:RETROCLOUD_AZ_STORAGE_ACCOUNT_KEY
+
+# Attempt to download the file. The cmdlet will return an error if the file doesn't exist.
+Get-AzStorageFileContent `
+    -Context $ctx `
+    -ShareName $env:RETROCLOUD_AZ_FILE_SHARE_NAME `
+    -Path "RetroPie/roms/scummvm/MysteryHouse.zip" `
+    -Verbose
+
+# It didn't fail and error out, so it successed.
+'Success. ROM found in Azure File Share.'
+
+# Cleanup
+Remove-Item .\MysteryHouse.zip -Verbose


### PR DESCRIPTION
Following PR #5 that would download [the freeware game Mystery House](https://www.scummvm.org/games/#mysthous) for testing. This PR checks that the ROM downloaded to the VM shows up in the Azure File Share. That proves that the VM has successfully mounted the Azure File Share as a directory and has write access to it.

Also prints the Azure File Share directory listing for convenience. Example output:
```
/retro-cloud/.emulationstation/downloaded_media/scummvm/screenshots/MysteryHouse.png
/retro-cloud/.emulationstation/gamelists/scummvm/gamelist.xml
/retro-cloud/cache/scummvm/covers/screenscraper/e6bdc488677a3ff312cccfa6fbd2e6257475bdb0
/retro-cloud/cache/scummvm/screenshots/screenscraper/e6bdc488677a3ff312cccfa6fbd2e6257475bdb0
/retro-cloud/cache/scummvm/db.xml
/retro-cloud/cache/scummvm/priorities.xml
/retro-cloud/cache/scummvm/quickid.xml
/retro-cloud/RetroPie/roms/scummvm/MysteryHouse.zip
```

Known limitation: Same as PR #5. Mounting the VM on the RPi is not possible on the container running in CircleCI, so currently it's not possible verify that the ROM in Azure File Share is visible to the RPi.

This PR is just for convenience in the future to see what had to change in the scripts to support the merged feature.