### PR TITLE
Fix failing screenscraper builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,9 @@ jobs:
             mkdir ~/tmp
             bash -i ssh-vm.sh "curl -L -o ~/tmp/test-gamelist.sh https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist.sh"
             bash -i ssh-vm.sh "curl -L -o ~/tmp/test-gamelist.xml -nv https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist.xml"
+            bash -i ssh-vm.sh "curl -L -o ~/tmp/test-gamelist-screenscraper-failed.xml -nv https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist-screenscraper-failed.xml"
             bash -i ssh-vm.sh "bash -i ~/tmp/test-gamelist.sh"
-            bash -i ssh-vm.sh "rm ~/tmp/test-gamelist.sh ~/tmp/test-gamelist.xml"
+            bash -i ssh-vm.sh "rm ~/tmp/test-gamelist.sh ~/tmp/test-gamelist.xml ~/tmp/test-gamelist-screenscraper-failed.xml"
 
     - run:
         name: Print RaspberryPi ~/.bashrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,9 @@ jobs:
     - run:
         name: Verify scraper output on VM
         command: |
-            mkdir ~/tmp
             bash -i ssh-vm.sh "curl -L -o ~/tmp/test-gamelist.sh https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist.sh"
-            bash -i ssh-vm.sh "curl -L -o ~/tmp/test-gamelist.xml -nv https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist.xml"
-            bash -i ssh-vm.sh "curl -L -o ~/tmp/test-gamelist-screenscraper-failed.xml -nv https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist-screenscraper-failed.xml"
+            bash -i ssh-vm.sh "curl -L -o ~/tmp/test-gamelist.xml https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist.xml"
+            bash -i ssh-vm.sh "curl -L -o ~/tmp/test-gamelist-screenscraper-failed.xml https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist-screenscraper-failed.xml"
             bash -i ssh-vm.sh "bash -i ~/tmp/test-gamelist.sh"
             bash -i ssh-vm.sh "rm ~/tmp/test-gamelist.sh ~/tmp/test-gamelist.xml ~/tmp/test-gamelist-screenscraper-failed.xml"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,13 @@ jobs:
         command: bash -i ssh-vm.sh "curl -L https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-copy-rom.sh | bash -i"
 
     - run:
+        name: Add Screenscraper.fr credentials to VM
+        command: |
+            bash -i ssh-vm.sh "echo '' | tee -a ~/.skyscraper/config.ini"
+            bash -i ssh-vm.sh "echo '[screenscraper]' | tee -a ~/.skyscraper/config.ini"
+            bash -i ssh-vm.sh "echo 'userCreds=\"${SCREENSCRAPER_USER}:${SCREENSCRAPER_KEY}\"' | tee -a ~/.skyscraper/config.ini"
+
+    - run:
         name: Run scraper on VM
         command: bash -i run-scraper.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,11 @@ jobs:
         when: always
 
     - run:
+        name: Print VM Skyscraper config
+        command: bash -i ssh-vm.sh "cat ~/.skyscraper/config.ini"
+        when: always
+
+    - run:
         name: Teardown Azure resources
         command: |
             curl -OL "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/teardown.sh"

--- a/virtual-machine/dev/test-gamelist-screenscraper-failed.xml
+++ b/virtual-machine/dev/test-gamelist-screenscraper-failed.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<gameList>
+  <game>
+    <path>/home/pi/RetroPie/roms/scummvm/MysteryHouse.zip</path>
+    <name>Mystery House</name>
+    <cover />
+    <image />
+    <marquee />
+    <video />
+    <rating />
+    <desc />
+    <releasedate />
+    <developer />
+    <publisher />
+    <genre />
+    <players />
+  </game>
+</gameList>

--- a/virtual-machine/dev/test-gamelist.sh
+++ b/virtual-machine/dev/test-gamelist.sh
@@ -6,7 +6,17 @@ set -eu
 if diff "$RETROCLOUD_VM_SHARE/.emulationstation/gamelists/scummvm/gamelist.xml" ~/tmp/test-gamelist.xml
 then
     echo "Scraping was successful"
-else
-    echo "Scraping failed somehow because the gamelist isn't as expected. See details above."
-    exit 1
+    exit 0
 fi
+
+echo "Scraping failed somehow because the gamelist isn't as expected. See details above."
+
+echo "This could be due to Screenscraper.fr often having API issues. Trying again with a slimmer XML."
+if diff "$RETROCLOUD_VM_SHARE/.emulationstation/gamelists/scummvm/gamelist.xml" ~/tmp/test-gamelist-screenscraper-failed.xml
+then
+    echo "Matched. Assuming it was a fluke."
+    exit 0
+fi
+
+echo "No something's definitely wrong. See details above."
+exit 1


### PR DESCRIPTION
[Screenscraper.fr](https://screenscraper.fr) started to have issues again. [Skyscraper](https://github.com/muldjord/skyscraper) detects this and outputs a helpful message:

> The screenscraper service is currently closed or too busy to handle requests from unregistered and inactive users. Sign up for an account at https://www.screenscraper.fr and contribute to the database to gain more threads. Then use the credentials with Skyscraper using the '-u [user:password]' command line option or by setting 'userCreds=[user:password]' in '~/.skyscraper/config.ini'.

Without the metadata the "Verify scraper output on VM" CI step fails the build. This has happened before and re-running the build has worked, but today it was failing most of the evening. To mitigate failing builds there are two solutions added:

1. `double-check-screenscraper-result`: Fallback to a simpler XML to test against. It only has the name, which [thegamesdb](https://thegamesdb.net/) is able to provide.
1. `use-screenscraper-credentials`: I have an account at Screenscraper.fr, and also donate monthly, which gives me priority and more threads. Adding the user's credentials to the Skyscraper config is something I want to support but there's guerilla version of it in the CircleCI config now to increase the likelihood of getting a result from the API.

> _This PR is just for convenience in the future to see what had to change in the scripts to support the merged feature._