### PR TITLE
Validate the Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  infra:
+  scriptValidation:
     docker:
     - image: seriema/retro-cloud:develop
     shell: /bin/bash --login -eo pipefail
@@ -101,8 +101,21 @@ jobs:
             rm teardown-az.ps1
         when: always
 
+  imageValidation:
+    docker:
+    - image: seriema/retro-cloud:develop
+    working_directory: /home/pi/retro-cloud
+    steps:
+
+    - checkout
+
+    - run:
+        name: Validate Docker image
+        command: bash docker/compose/run_tests.sh
+
 workflows:
   version: 2
-  build:
+  commit:
     jobs:
-    - infra
+    - scriptValidation
+    - imageValidation

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ An expensive and over-engineered approach to storing ROMs and their metadata whi
 * Testing
     * `docker run --privileged -it --rm seriema/retro-cloud:develop`
     * `docker/compose/run_tests.sh`
+    * `docker-compose -f docker-compose.test.yml up`
 * Docker
     * `docker build -t seriema/retro-cloud:amd64 .`
     * `docker push seriema/retro-cloud:amd64`

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ An expensive and over-engineered approach to storing ROMs and their metadata whi
     * `git clone git@github.com:seriema/retro-cloud.git && cd retro-cloud && git checkout develop`
 * Testing
     * `docker run --privileged -it --rm seriema/retro-cloud:develop`
+    * `docker/compose/run_tests.sh`
 * Docker
     * `docker build -t seriema/retro-cloud:amd64 .`
     * `docker push seriema/retro-cloud:amd64`

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,6 @@
+sut:
+    build: .
+    working_dir: /home/pi/retro-cloud-test
+    volumes:
+        - ./docker/compose:/home/pi/retro-cloud-test/docker/compose
+    command: bash docker/compose/run_tests.sh

--- a/docker/compose/directory-listing.sh
+++ b/docker/compose/directory-listing.sh
@@ -4,19 +4,14 @@
 set -eux
 
 echo 'Verify number of roms folders. There is one for each successful emultator installed.'
-# Two emulators aren't available on amd64: mame-mame4all, amiga
+# Note: Export a new list with: $ ls -m ~/RetroPie/roms
 if [[ $(uname -m) = 'armv7l' ]]; then
-    emulators=32;
+    emulators="amiga, amstradcpc, arcade, atari2600, atari5200, atari7800, atari800, atarilynx, fba, fds, gamegear, gb, gba, gbc, genesis, mame-libretro, mame-mame4all, mastersystem, megadrive, n64, neogeo, nes, ngp, ngpc, pcengine, psx, sega32x, segacd, sg-1000, snes, vectrex, zxspectrum";
 else
-    emulators=30;
+    # Two emulators aren't available on amd64: mame-mame4all, amiga
+    emulators="amstradcpc, arcade, atari2600, atari5200, atari7800, atari800, atarilynx, fba, fds, gamegear, gb, gba, gbc, genesis, mame-libretro, mastersystem, megadrive, n64, neogeo, nes, ngp, ngpc, pcengine, psx, sega32x, segacd, sg-1000, snes, vectrex, zxspectrum";
 fi
-
-if  [[ $(ls ~/RetroPie/roms | wc -l) -ne $emulators ]]; then
-    echo "Not enough roms folders. Did an emulator fail to install?"
-    echo "These were installed:"
-    ls ~/RetroPie/roms
-    exit 1
-fi
+[[ -z $(echo $(echo $emulators | tr ',' '\n') $(ls -1 ~/RetroPie/roms) | tr ' ' '\n' | sort | uniq -u) ]]
 
 echo 'Verify that there are no builds left. There is one for each failed build.'
 [[ -z $(find /home/pi/RetroPie-Setup/tmp/build -maxdepth 3 -type f) ]]

--- a/docker/compose/directory-listing.sh
+++ b/docker/compose/directory-listing.sh
@@ -5,13 +5,13 @@ set -eux
 
 echo 'Verify number of roms folders. There is one for each successful emultator installed.'
 # Two emulators aren't available on amd64: mame-mame4all, amiga
-if [ "$(uname -m)" = 'armv7l' ]; then
-    emulators='32';
+if [[ $(uname -m) = 'armv7l' ]]; then
+    emulators=32;
 else
-    emulators='30';
+    emulators=30;
 fi
 
-if [ ! $(ls ~/RetroPie/roms | wc -l) == $emulators ]; then
+if  [[ $(ls ~/RetroPie/roms | wc -l) -ne $emulators ]]; then
     echo "Not enough roms folders. Did an emulator fail to install?"
     echo "These were installed:"
     ls ~/RetroPie/roms
@@ -19,7 +19,7 @@ if [ ! $(ls ~/RetroPie/roms | wc -l) == $emulators ]; then
 fi
 
 echo 'Verify that there are no builds left. There is one for each failed build.'
-[ -z "`find /home/pi/RetroPie-Setup/tmp/build -maxdepth 3 -type f`" ]
+[[ -z $(find /home/pi/RetroPie-Setup/tmp/build -maxdepth 3 -type f) ]]
 
 echo 'Verify that line endings of all files are LF. Windows uses CRLF which can get copied over by Docker ADD/COPY.'
-[ ! "$(grep -r $'\r' * -l)" ]
+[[ -z $(grep -r $'\r' * -l) ]]

--- a/docker/compose/directory-listing.sh
+++ b/docker/compose/directory-listing.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Abort on error, and error if variable is unset
-set -eu
+# Abort on error, error if variable is unset, and enable debug output
+set -eux
 
 echo 'Verify number of roms folders. There is one for each successful emultator installed.'
 # Two emulators aren't available on amd64: mame-mame4all, amiga

--- a/docker/compose/directory-listing.sh
+++ b/docker/compose/directory-listing.sh
@@ -20,3 +20,6 @@ fi
 
 echo 'Verify that there are no builds left. There is one for each failed build.'
 [ -z "`find /home/pi/RetroPie-Setup/tmp/build -maxdepth 3 -type f`" ]
+
+echo 'Verify that line endings of all files are LF. Windows uses CRLF which can get copied over by Docker ADD/COPY.'
+[ ! "$(grep -r $'\r' * -l)" ]

--- a/docker/compose/directory-listing.sh
+++ b/docker/compose/directory-listing.sh
@@ -4,6 +4,7 @@
 set -eux
 
 echo 'Verify number of roms folders. There is one for each successful emultator installed.'
+# Added when RetroPie-Setup was failing silently and not installing all emulators.
 # Note: Export a new list with: $ ls -m ~/RetroPie/roms
 if [[ $(uname -m) = 'armv7l' ]]; then
     emulators="amiga, amstradcpc, arcade, atari2600, atari5200, atari7800, atari800, atarilynx, fba, fds, gamegear, gb, gba, gbc, genesis, mame-libretro, mame-mame4all, mastersystem, megadrive, n64, neogeo, nes, ngp, ngpc, pcengine, psx, sega32x, segacd, sg-1000, snes, vectrex, zxspectrum";
@@ -14,7 +15,11 @@ fi
 [[ -z $(echo $(echo $emulators | tr ',' '\n') $(ls -1 ~/RetroPie/roms) | tr ' ' '\n' | sort | uniq -u) ]]
 
 echo 'Verify that there are no builds left. There is one for each failed build.'
+# Added when RetroPie-Setup was failing silently and not installing all emulators.
 [[ -z $(find /home/pi/RetroPie-Setup/tmp/build -maxdepth 3 -type f) ]]
 
 echo 'Verify that line endings of all files are LF. Windows uses CRLF which can get copied over by Docker ADD/COPY.'
+# Added when running the container would throw '\r' parse errors when the users bash profile. Despite
+# .gitattribute set to checkout all files in docker/rpi as LF it could still check them out as CRLF,
+# and Docker has a tendency to use the host line endings when copying files.
 [[ -z $(grep -r $'\r' * -l) ]]

--- a/docker/compose/directory-listing.sh
+++ b/docker/compose/directory-listing.sh
@@ -4,7 +4,14 @@
 set -eu
 
 echo 'Verify number of roms folders. There is one for each successful emultator installed.'
-if [ ! $(ls ~/RetroPie/roms | wc -l) == '30' ]; then
+# Two emulators aren't available on amd64: mame-mame4all, amiga
+if [ "$(uname -m)" = 'armv7l' ]; then
+    emulators='32';
+else
+    emulators='30';
+fi
+
+if [ ! $(ls ~/RetroPie/roms | wc -l) == $emulators ]; then
     echo "Not enough roms folders. Did an emulator fail to install?"
     echo "These were installed:"
     ls ~/RetroPie/roms

--- a/docker/compose/directory-listing.sh
+++ b/docker/compose/directory-listing.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Abort on error, and error if variable is unset
+set -eu
+
+echo 'Verify number of roms folders. There is one for each successful emultator installed.'
+if [ ! $(ls ~/RetroPie/roms | wc -l) == '30' ]; then
+    echo "Not enough roms folders. Did an emulator fail to install?"
+    echo "These were installed:"
+    ls ~/RetroPie/roms
+    exit 1
+fi
+
+echo 'Verify that there are no builds left. There is one for each failed build.'
+[ -z "`find /home/pi/RetroPie-Setup/tmp/build -maxdepth 3 -type f`" ]

--- a/docker/compose/packages.sh
+++ b/docker/compose/packages.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Abort on error, and error if variable is unset
+set -eu
+
+echo 'Verify that apt-get is not broken'
+[[ $(sudo apt-get update) ]]

--- a/docker/compose/packages.sh
+++ b/docker/compose/packages.sh
@@ -3,5 +3,7 @@
 # Abort on error, error if variable is unset, and enable debug output
 set -eux
 
-echo 'Verify that apt-get is not broken'
+echo 'Verify that apt-get is not broken due to wrong package sources, repo public keys, etc.'
+# Added when apt-get would not update on Windows because there were Raspberry Pi Foundation apt-get
+# sources expecting arm32, and when not having the right public keys validating those sources.
 [[ $(sudo apt-get update) ]]

--- a/docker/compose/packages.sh
+++ b/docker/compose/packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Abort on error, and error if variable is unset
-set -eu
+# Abort on error, error if variable is unset, and enable debug output
+set -eux
 
 echo 'Verify that apt-get is not broken'
 [[ $(sudo apt-get update) ]]

--- a/docker/compose/run_tests.sh
+++ b/docker/compose/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Abort on error, and error if variable is unset
-set -eu
+# Abort on error, error if variable is unset, and enable debug output
+set -eux
 
 echo 'TEST: directory listing'
 ./docker/compose/directory-listing.sh

--- a/docker/compose/run_tests.sh
+++ b/docker/compose/run_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Abort on error, and error if variable is unset
+set -eu
+
+echo 'TEST: directory listing'
+./docker/compose/directory-listing.sh
+
+echo 'TEST: user access'
+./docker/compose/user-access.sh
+
+echo 'TEST: Done.'

--- a/docker/compose/run_tests.sh
+++ b/docker/compose/run_tests.sh
@@ -6,6 +6,9 @@ set -eu
 echo 'TEST: directory listing'
 ./docker/compose/directory-listing.sh
 
+echo 'TEST: packages'
+./docker/compose/packages.sh
+
 echo 'TEST: user access'
 ./docker/compose/user-access.sh
 

--- a/docker/compose/user-access.sh
+++ b/docker/compose/user-access.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Abort on error, and error if variable is unset
+set -eu
+
+echo 'Verify access rights on user home and RetroPie'
+[ $(stat -c %a /home/pi) -eq 755 ]
+[ $(stat -c %a /home/pi/RetroPie) -eq 755 ]
+[ $(stat -c %a /home/pi/RetroPie-Setup) -eq 755 ]
+
+echo 'Verify group memberships'
+[ "$(groups | grep pi)" ]
+[ "$(groups | grep sudo)" ]
+
+echo 'Verify username'
+[ "$(whoami)" = "pi" ]

--- a/docker/compose/user-access.sh
+++ b/docker/compose/user-access.sh
@@ -3,15 +3,24 @@
 # Abort on error, error if variable is unset, and enable debug output
 set -eux
 
-echo 'Verify access rights on user home and RetroPie'
+echo 'Verify access permissions of different directories'
+# Added when the user was created as root so the user didn't have regular access to $HOME.
 [[ $(stat -c %a /home/pi) -eq 755 ]]
+# Added when RetroPie-Setup was running as another user than expected so the user didn't have access.
 [[ $(stat -c %a /home/pi/RetroPie) -eq 755 ]]
+# Added when 'git clone' required chmod but shouldn't have needed to.
 [[ $(stat -c %a /home/pi/RetroPie-Setup) -eq 755 ]]
+# Note: /dev/fuse test is only available at runtime so this test doesn't test the image. It would
+# test the running container. It's only a problem when running the container on Windows/amd64 but
+# it means that mounting won't work and running raspberry-pi/mount-vm-share.sh will fail.
 # [[ $(stat -c %a /dev/fuse) -eq 666 ]]
 
 echo 'Verify group memberships'
+# Added when replacing 'useradd' with 'adduser' to verify that the user gets a group with the same name.
 [[ $(groups | grep pi) ]]
+# Added when replacing 'useradd' with 'adduser' to verify that the user is still given sudo rights.
 [[ $(groups | grep sudo) ]]
 
-echo 'Verify username'
+echo 'Verify that the image default user is "pi"'
+# Added when not setting "USER pi" as the last user in the Dockerfile.
 [[ $(whoami) = "pi" ]]

--- a/docker/compose/user-access.sh
+++ b/docker/compose/user-access.sh
@@ -4,13 +4,13 @@
 set -eux
 
 echo 'Verify access rights on user home and RetroPie'
-[ $(stat -c %a /home/pi) -eq 755 ]
-[ $(stat -c %a /home/pi/RetroPie) -eq 755 ]
-[ $(stat -c %a /home/pi/RetroPie-Setup) -eq 755 ]
+[[ $(stat -c %a /home/pi) -eq 755 ]]
+[[ $(stat -c %a /home/pi/RetroPie) -eq 755 ]]
+[[ $(stat -c %a /home/pi/RetroPie-Setup) -eq 755 ]]
 
 echo 'Verify group memberships'
-[ "$(groups | grep pi)" ]
-[ "$(groups | grep sudo)" ]
+[[ $(groups | grep pi) ]]
+[[ $(groups | grep sudo) ]]
 
 echo 'Verify username'
-[ "$(whoami)" = "pi" ]
+[[ $(whoami) = "pi" ]]

--- a/docker/compose/user-access.sh
+++ b/docker/compose/user-access.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Abort on error, and error if variable is unset
-set -eu
+# Abort on error, error if variable is unset, and enable debug output
+set -eux
 
 echo 'Verify access rights on user home and RetroPie'
 [ $(stat -c %a /home/pi) -eq 755 ]

--- a/docker/compose/user-access.sh
+++ b/docker/compose/user-access.sh
@@ -7,6 +7,7 @@ echo 'Verify access rights on user home and RetroPie'
 [[ $(stat -c %a /home/pi) -eq 755 ]]
 [[ $(stat -c %a /home/pi/RetroPie) -eq 755 ]]
 [[ $(stat -c %a /home/pi/RetroPie-Setup) -eq 755 ]]
+# [[ $(stat -c %a /dev/fuse) -eq 666 ]]
 
 echo 'Verify group memberships'
 [[ $(groups | grep pi) ]]


### PR DESCRIPTION
While working on arm32v7 (RPi 3) support it's been quite easy to accidentally create an image that is different (i.e. wrong) compared to previous versions of the Docker image or more importantly: different from a real RPi with RetroPie. These tests have grown organically while working on the branch `docker-multiarch` but are worth splitting out.

* The tests are meant to run inside the Docker container and will validate directory structure, package management, and user access.
* Tests run on every commit on:
    * Docker Hub as an [Autotest](https://docs.docker.com/docker-hub/builds/automated-testing/#set-up-automated-test-files), and verifies the built Docker image. [See example log.](https://hub.docker.com/repository/registry-1.docker.io/seriema/retro-cloud/builds/f9a30111-a4dd-49a0-a309-d10e8d236f2a)
    * CircleCI as a [concurrent job](https://circleci.com/docs/2.0/jobs-steps/#sample-configuration-with-concurrent-jobs), but _always runs against the development image `seriema/retro-cloud:develop`_ available on Docker Hub. [See example log.](https://app.circleci.com/pipelines/github/seriema/retro-cloud/jobs/480)
* Tests can be run locally by either:
    * Using Docker compose.
    * Mounting the /docker/compose directory as a volume and calling the run_tests.sh from within the running container.

> _This PR is just for convenience in the future to see what had to change in the scripts to support the merged feature._