### PR TITLE
Fix debconf warnings in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN apt-get update \
     # Required to run image as non-root user
     sudo
 
+# Get rid of the warning: "debconf: unable to initialize frontend: Dialog"
+# https://github.com/moby/moby/issues/27988
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 # Get rid of the warning: "debconf: delaying package configuration, since apt-utils is not installed"
 RUN apt-get install -y apt-utils
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update \
     # Required to run image as non-root user
     sudo
 
+# Get rid of the warning: "debconf: delaying package configuration, since apt-utils is not installed"
+RUN apt-get install -y apt-utils
+
 # Mimic RaspberryPi: Create a user called "pi" without a password that's in the groups pi and sudo
 # Use `adduser` instead of `useradd`:
 # * https://github.com/RetroPie/RetroPie-Setup/issues/2165#issuecomment-337932294


### PR DESCRIPTION
Fixes two warnings in the Docker builds:
1. "debconf: delaying package configuration, since apt-utils is not installed"
    * Installing `apt-utils` resolves it. Did it in a separate cache layer for transparency, so the first `apt-get install` above it and it's own install still outputs the warning.
1. "debconf: unable to initialize frontend: Dialog"
    * The fix for this is from https://github.com/moby/moby/issues/27988, but I think it would be persisted in the image. Which we might not want (see below).
    * Another solution [from StackOverflow](https://stackoverflow.com/a/35976127/703921) is using `ENV` but it would be persisted for the users of the image and thus not recommended. The proposed solution in that link uses `ARG` but [did not work](https://hub.docker.com/repository/registry-1.docker.io/seriema/retro-cloud/builds/36c858ec-94be-434e-a485-c7de0565be8d).
        * This image is based on Ubuntu 18.04 which could be the reason. The one in `docker-multiarch` is based on Debian:stretch and it seems to work there. (At the moment of writing I'm waiting for [final build](https://hub.docker.com/repository/registry-1.docker.io/seriema/retro-cloud/builds/d54a036a-02ca-4a59-8ca8-f26186d49b2c))

> _This PR is just for convenience in the future to see what had to change in the scripts to support the merged feature._