### PR TITLE
Lint bash scripts with shellcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,16 @@ jobs:
     - checkout
 
     - run:
+        name: Validate scripts execution permission
+        command: |
+            findFilesWithoutExecutionPermission () { find . -type f -name '*.sh' -not -executable; }
+            if [ $(findFilesWithoutExecutionPermission | wc -l) -ne 0 ]; then
+                echo 'These files are lacking execute (+x) permission:'
+                findFilesWithoutExecutionPermission
+                exit 1;
+            fi
+
+    - run:
         name: Lint Scripts
         command: find . -type f -name '*.sh' | xargs shellcheck --external-sources
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,16 @@
 version: 2
 jobs:
+  bashValidation:
+    docker:
+    - image: koalaman/shellcheck-alpine:stable
+    steps:
+
+    - checkout
+
+    - run:
+        name: Lint Scripts
+        command: find . -type f -name '*.sh' | xargs shellcheck --external-sources
+
   scriptValidation:
     docker:
     - image: seriema/retro-cloud:develop
@@ -131,5 +142,6 @@ workflows:
   version: 2
   commit:
     jobs:
+    - bashValidation
     - scriptValidation
     - imageValidation

--- a/docker/compose/directory-listing.sh
+++ b/docker/compose/directory-listing.sh
@@ -12,6 +12,8 @@ else
     # Two emulators aren't available on amd64: mame-mame4all, amiga
     emulators="amstradcpc, arcade, atari2600, atari5200, atari7800, atari800, atarilynx, fba, fds, gamegear, gb, gba, gbc, genesis, mame-libretro, mastersystem, megadrive, n64, neogeo, nes, ngp, ngpc, pcengine, psx, sega32x, segacd, sg-1000, snes, vectrex, zxspectrum";
 fi
+# Disable lint: this was tedious to validate and it uses word splitting on purpose
+# shellcheck disable=SC2046
 [[ -z $(echo $(echo "$emulators" | tr ',' '\n') $(ls -1 ~/RetroPie/roms) | tr ' ' '\n' | sort | uniq -u) ]]
 
 echo 'Verify that there are no builds left. There is one for each failed build.'

--- a/docker/compose/directory-listing.sh
+++ b/docker/compose/directory-listing.sh
@@ -25,4 +25,4 @@ echo 'Verify that line endings of all files are LF. Windows uses CRLF which can 
 # Note: The Dockerfile no longer copies bash files because COPY constantly invalidates the cache, forcing
 # unnecessary rebuilds that take 30-60 minutes locally and 2-3 hours on Docker Hub. The test is kept
 # as a regression test for future changes to the Dockerfile.
-[[ -z $(grep -r $'\r' * -l) ]]
+! grep -r $'\r' * -l -q

--- a/docker/compose/directory-listing.sh
+++ b/docker/compose/directory-listing.sh
@@ -12,7 +12,7 @@ else
     # Two emulators aren't available on amd64: mame-mame4all, amiga
     emulators="amstradcpc, arcade, atari2600, atari5200, atari7800, atari800, atarilynx, fba, fds, gamegear, gb, gba, gbc, genesis, mame-libretro, mastersystem, megadrive, n64, neogeo, nes, ngp, ngpc, pcengine, psx, sega32x, segacd, sg-1000, snes, vectrex, zxspectrum";
 fi
-[[ -z $(echo $(echo $emulators | tr ',' '\n') $(ls -1 ~/RetroPie/roms) | tr ' ' '\n' | sort | uniq -u) ]]
+[[ -z $(echo $(echo "$emulators" | tr ',' '\n') $(ls -1 ~/RetroPie/roms) | tr ' ' '\n' | sort | uniq -u) ]]
 
 echo 'Verify that there are no builds left. There is one for each failed build.'
 # Added when RetroPie-Setup was failing silently and not installing all emulators.

--- a/docker/compose/directory-listing.sh
+++ b/docker/compose/directory-listing.sh
@@ -25,4 +25,4 @@ echo 'Verify that line endings of all files are LF. Windows uses CRLF which can 
 # Note: The Dockerfile no longer copies bash files because COPY constantly invalidates the cache, forcing
 # unnecessary rebuilds that take 30-60 minutes locally and 2-3 hours on Docker Hub. The test is kept
 # as a regression test for future changes to the Dockerfile.
-! grep -r $'\r' * -l -q
+! grep -r $'\r' ./* -l -q

--- a/docker/compose/user-access.sh
+++ b/docker/compose/user-access.sh
@@ -17,9 +17,9 @@ echo 'Verify access permissions of different directories'
 
 echo 'Verify group memberships'
 # Added when replacing 'useradd' with 'adduser' to verify that the user gets a group with the same name.
-[[ $(groups | grep pi) ]]
+groups | grep -q pi
 # Added when replacing 'useradd' with 'adduser' to verify that the user is still given sudo rights.
-[[ $(groups | grep sudo) ]]
+groups | grep -q sudo
 
 echo 'Verify that the image default user is "pi"'
 # Added when not setting "USER pi" as the last user in the Dockerfile.

--- a/raspberry-pi/install-ps.sh
+++ b/raspberry-pi/install-ps.sh
@@ -17,7 +17,7 @@ fi
 ###################################
 # Download and extract PowerShell
 
-if [ $(uname -m) == 'x86_64' ]; then
+if [[ $(uname -m) == 'x86_64' ]]; then
     # Only used during development in a Azure VM or Docker, both based on Ubuntu.
     arch=x64
 else

--- a/raspberry-pi/local/ssh-vm.sh
+++ b/raspberry-pi/local/ssh-vm.sh
@@ -7,4 +7,4 @@ set -e
 # Error if variable is unset
 set -u
 
-ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP $vmCmd
+ssh "${RETROCLOUD_VM_USER}@${RETROCLOUD_VM_IP}" "$vmCmd"

--- a/raspberry-pi/local/ssh-vm.sh
+++ b/raspberry-pi/local/ssh-vm.sh
@@ -7,4 +7,6 @@ set -e
 # Error if variable is unset
 set -u
 
+# Lint disable: We do want the command to expand on the client side.
+# shellcheck disable=SC2029
 ssh "${RETROCLOUD_VM_USER}@${RETROCLOUD_VM_IP}" "$vmCmd"

--- a/raspberry-pi/mount-vm-share.sh
+++ b/raspberry-pi/mount-vm-share.sh
@@ -26,16 +26,12 @@ sudo sed -i "1s+^+$mntCmd\n+" /opt/retropie/configs/all/autostart.sh
 
 echo 'Attempt to mount VM now to avoid a reboot ...'
 # Allow it to fail. Which can happen in a container without privileges, or certain access rights issues.
-(
-    set +e
-    $mntCmd
-    if [[ $? -eq 0 ]]; then
-        echo '... mounted successfully.'
-    else
-        echo '... WARNING! Could not mount VM. You need to restart before continuing. It could also be a problem with your privilegies.' 1>&2
-    fi
-    set -e
-)
+if $mntCmd
+then
+    echo '... mounted successfully.'
+else
+    echo '... WARNING! Could not mount VM. You need to restart before continuing. It could also be a problem with your privilegies.' 1>&2
+fi
 
 echo 'Backup gamelists as ~/.emulationstation/gamelists.bak'
 mv "${HOME}/.emulationstation/gamelists" "${HOME}/.emulationstation/gamelists.bak"

--- a/raspberry-pi/mount-vm-share.sh
+++ b/raspberry-pi/mount-vm-share.sh
@@ -13,8 +13,8 @@ echo 'Create a folder for the mount point'
 # TODO: RETROCLOUD_AZ_RESOURCE_GROUP is currently considered a debug name but perhaps I should save the generated "prefix" (or a system where Azure generates the names)
 # If these variables aren't available, make sure this script is running in interactive mode (https://stackoverflow.com/a/43660876) and mount-az-share.sh.
 mntPath="/mnt/$RETROCLOUD_AZ_RESOURCE_GROUP"
-sudo mkdir -p $mntPath
-sudo chmod 777 $mntPath
+sudo mkdir -p "$mntPath"
+sudo chmod 777 "$mntPath"
 
 echo 'Create a persistent mount point in autostart.sh'
 # If these variables aren't available, make sure this script is running in interactive mode (https://stackoverflow.com/a/43660876) and create-vm.ps1.
@@ -38,13 +38,13 @@ echo 'Attempt to mount VM now to avoid a reboot ...'
 )
 
 echo 'Backup gamelists as ~/.emulationstation/gamelists.bak'
-mv $HOME/.emulationstation/gamelists $HOME/.emulationstation/gamelists.bak
+mv "${HOME}/.emulationstation/gamelists" "${HOME}/.emulationstation/gamelists.bak"
 
 echo 'Backup downloaded media as ~/.emulationstation/downloaded_media.bak'
-mv $HOME/.emulationstation/downloaded_media $HOME/.emulationstation/downloaded_media.bak || echo 'Directory unavailable. Assuming a fresh install where EmulationStation has not run yet.'
+mv "${HOME}/.emulationstation/downloaded_media" "${HOME}/.emulationstation/downloaded_media.bak" || echo 'Directory unavailable. Assuming a fresh install where EmulationStation has not run yet.'
 
 echo 'Backup ROMs as ~/RetroPie/roms.bak'
-mv $HOME/RetroPie/roms $HOME/RetroPie/roms.bak
+mv "${HOME}/RetroPie/roms" "${HOME}/RetroPie/roms.bak"
 
 echo 'Symlink the mounted folders to look like a RetroPie installation'
 gamelists="$mntPath/.emulationstation/gamelists"

--- a/raspberry-pi/setup.sh
+++ b/raspberry-pi/setup.sh
@@ -37,4 +37,4 @@ chmod +x "$HOME/ssh-vm.sh"
 
 echo "SETUP: Done!"
 
-echo 'SETUP: Note, you need to load the environment variables! Start a new interactive shell with `bash -i`.'
+echo "SETUP: Note, you need to load the environment variables! Start a new interactive shell with 'bash -i'."

--- a/raspberry-pi/setup.sh
+++ b/raspberry-pi/setup.sh
@@ -11,7 +11,7 @@ if [[ "${AZURE_SERVICE_PRINCIPAL_SECRET:-missing}" == "missing" ]]; then
     # https://stackoverflow.com/a/1885534
     read -p "Ready to continue [y/N]? " -r
     if [[ ! $REPLY =~ ^y|Y|[yY][eE][sS]$ ]]; then
-        [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
+        [[ "$0" = "${BASH_SOURCE[*]}" ]] && exit 1 || return 1
     fi
 fi
 

--- a/virtual-machine/local/run-skyscraper.sh
+++ b/virtual-machine/local/run-skyscraper.sh
@@ -111,18 +111,18 @@ do
 
     # "arcadedb" only has MAME games
     if [[ $platform == *"mame"* ]]; then
-        Skyscraper -p $platform -s 'arcadedb'
+        Skyscraper -p "$platform" -s 'arcadedb'
     fi
 
     # TODO: If there are no games found, run the "screenscraper" module again but with the --unpack flag?
 
     for module in "${modules[@]}"
     do
-        Skyscraper -p $platform -s $module
+        Skyscraper -p "$platform" -s "$module"
     done
 
     echo "Generating gamelists and artwork for $platform"
-    Skyscraper -p $platform
+    Skyscraper -p "$platform"
 
     # This step is needed because the AZ mounted path is reflected in the gamelists, and they're symlinked on the rpi to look local.
     echo "Fixing paths in gamelists for $platform"

--- a/virtual-machine/mount-az-share.sh
+++ b/virtual-machine/mount-az-share.sh
@@ -26,7 +26,8 @@ if [[ ! -d $mntPath ]]; then
 fi
 
 echo 'Add a persistent mount point entry for the Azure file share in /etc/fstab'
-if [[ -z $(grep "$RETROCLOUD_AZ_FILE_SHARE_URL $mntPath" /etc/fstab) ]]; then
+if ! grep -q "$RETROCLOUD_AZ_FILE_SHARE_URL $mntPath" /etc/fstab
+then
     echo "# RETRO-CLOUD: The changes below were made by retro-cloud" | sudo tee -a /etc/fstab > /dev/null
     echo "$RETROCLOUD_AZ_FILE_SHARE_URL $mntPath cifs _netdev,nofail,vers=3.0,credentials=$RETROCLOUD_AZ_FILE_SHARE_CREDENTIALS,dir_mode=0777,file_mode=0777,serverino" | sudo tee -a /etc/fstab > /dev/null
 else

--- a/virtual-machine/mount-az-share.sh
+++ b/virtual-machine/mount-az-share.sh
@@ -22,11 +22,11 @@ mntPath="$RETROCLOUD_VM_SHARE"
 # The folder is created during VM creation, but if unmount-az-share.sh has run then it's been deleted and needs to be recreated.
 if [[ ! -d $mntPath ]]; then
     echo 'Create the shared folder because it was missing'
-    mkdir -p $mntPath
+    mkdir -p "$mntPath"
 fi
 
 echo 'Add a persistent mount point entry for the Azure file share in /etc/fstab'
-if [ -z "$(grep $RETROCLOUD_AZ_FILE_SHARE_URL\ $mntPath /etc/fstab)" ]; then
+if [[ -z $(grep "$RETROCLOUD_AZ_FILE_SHARE_URL $mntPath" /etc/fstab) ]]; then
     echo "# RETRO-CLOUD: The changes below were made by retro-cloud" | sudo tee -a /etc/fstab > /dev/null
     echo "$RETROCLOUD_AZ_FILE_SHARE_URL $mntPath cifs _netdev,nofail,vers=3.0,credentials=$RETROCLOUD_AZ_FILE_SHARE_CREDENTIALS,dir_mode=0777,file_mode=0777,serverino" | sudo tee -a /etc/fstab > /dev/null
 else

--- a/virtual-machine/remove-vm-share.sh
+++ b/virtual-machine/remove-vm-share.sh
@@ -6,4 +6,4 @@ set -e
 set -u
 
 echo 'Remove the shared directory and symlinks'
-rm -r $RETROCLOUD_VM_SHARE
+rm -r "$RETROCLOUD_VM_SHARE"

--- a/virtual-machine/setup.sh
+++ b/virtual-machine/setup.sh
@@ -7,7 +7,7 @@ set -e
 # Error if variable is unset
 set -u
 
-if [[ ! -z $(find /home/pi/RetroPie-Setup -maxdepth 1) ]]; then
+if [[ -n $(find /home/pi/RetroPie-Setup -maxdepth 1) ]]; then
     echo "Are you running this script on the Raspberry Pi? It should be run from within the VM.";
     echo "SSH to the VM with `bash -i ~/ssh-vm.sh` and then call this script again.";
     echo "Or run `bash -i ~/setup-vm.sh` that will do it for you.";

--- a/virtual-machine/setup.sh
+++ b/virtual-machine/setup.sh
@@ -9,8 +9,8 @@ set -u
 
 if [[ -n $(find /home/pi/RetroPie-Setup -maxdepth 1) ]]; then
     echo "Are you running this script on the Raspberry Pi? It should be run from within the VM.";
-    echo "SSH to the VM with `bash -i ~/ssh-vm.sh` and then call this script again.";
-    echo "Or run `bash -i ~/setup-vm.sh` that will do it for you.";
+    echo "SSH to the VM with 'bash -i ~/ssh-vm.sh' and then call this script again.";
+    echo "Or run 'bash -i ~/setup-vm.sh' that will do it for you.";
     exit 1
 fi
 

--- a/virtual-machine/unmount-az-share.sh
+++ b/virtual-machine/unmount-az-share.sh
@@ -7,8 +7,8 @@ set -u
 
 echo 'Unmount the Azure File Share in the VMs shared folder.'
 mntPath="$RETROCLOUD_VM_SHARE"
-sudo umount $mntPath
-sudo rm -r -f $mntPath
+sudo umount "$mntPath"
+sudo rm -r -f "$mntPath"
 
 # Do not delete it because it can't be recreated from within the VM
 # echo 'Delete the credential file that stores the username and password for the file share.'


### PR DESCRIPTION
_Github has a weird bug with PR's on branches that get rebased. Sometimes it doesn't pick up the correct order of the commits. The right order here is not what is shown below. There is no sudden green build in the middle, that's actually the last commit._

Linting tools are always helpful to learn basic "gotcha" usages that too are easy to stumble into and really tricky to get out of.

[Shellcheck](https://github.com/koalaman/shellcheck) has an [online linter](https://www.shellcheck.net/) that's really useful for copy/paste work, and a [wiki full of rules](https://github.com/koalaman/shellcheck/wiki). These rules were detected by the tool and fixed:
* https://github.com/koalaman/shellcheck/wiki/SC2086
* https://github.com/koalaman/shellcheck/wiki/SC2181
* https://github.com/koalaman/shellcheck/wiki/SC2143
* https://github.com/koalaman/shellcheck/wiki/SC2236
* https://github.com/koalaman/shellcheck/wiki/SC2006
* https://github.com/koalaman/shellcheck/wiki/SC2035
* https://github.com/koalaman/shellcheck/wiki/SC2046
* https://github.com/koalaman/shellcheck/wiki/SC2128
* https://github.com/koalaman/shellcheck/wiki/SC2029

> _This PR is just for convenience in the future to see what had to change in the scripts to support the merged feature._