### PR TITLE
Min VM for user and Max VM for CI

### DIFF
--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_B2ms" | `
+    -VMSize "Standard_F2s_v2" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_A2_v2" | `
+    -VMSize "Standard_B2ms" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_B1ls" | `
+    -VMSize "Standard_B1s" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_F1s" | `
+    -VMSize "Standard_D1_v2" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_D1" | `
+    -VMSize "Standard_DS1" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -164,12 +164,20 @@ $username = "pi"
 $securePassword = ConvertTo-SecureString ' ' -AsPlainText -Force
 $cred = New-Object System.Management.Automation.PSCredential ($username, $securePassword)
 
-ProgressHelper $currentActivity "Creating the virtual machine configuration"
+if ($Env:CI) {
+    $vmSizeMessage="a fast and expensive VM for Continous Integration"
+    $vmSize="Standard_F1s"
+} else {
+    $vmSizeMessage="a cheap VM for the user to save money (can be upscaled in the Azure Portal)"
+    $vmSize="Standard_B1s"
+}
+
+ProgressHelper $currentActivity "Creating the virtual machine configuration with $vmSizeMessage"
 $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_F2s_v2" | `
+    -VMSize $vmSize | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_A0" | `
+    -VMSize "Standard_B1ms" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_B1ms" | `
+    -VMSize "Standard_A1" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_A1_v2" | `
+    -VMSize "Standard_F1" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_F1" | `
+    -VMSize "Standard_F1s" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_DS1_v2" | `
+    -VMSize "Standard_D1" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_DS1" | `
+    -VMSize "Standard_A2_v2" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_B2s" | `
+    -VMSize "Standard_B1ls" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_B1s" | `
+    -VMSize "Standard_A0" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_A1" | `
+    -VMSize "Standard_A1_v2" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -169,7 +169,7 @@ $vmName = "VM"
 $vmConfig = `
   New-AzVMConfig `
     -VMName $vmName `
-    -VMSize "Standard_D1_v2" | `
+    -VMSize "Standard_DS1_v2" | `
   Set-AzVMOperatingSystem `
     -Linux `
     -ComputerName $vmName `


### PR DESCRIPTION
1. **Lower cost to user**: The current VM costs ~29 USD/month so I'm looking at lowering it for the user to save money.
    * The `B1s` is 75% cheaper per month, and adds 1 minute to CI builds.
1. **Lower CI build times for me**: The current VM cost ~0.005 USD/build and take ~5 min to run so it could be worth paying for a more expensive VM if it speeds up the builds.
    * The `F1s` is 25% more expensive per month, and removes 1 minute from CI builds.
    * With aea708f it's now unlikely that a VM will be lingering due to a failed CI build, making this option more viable.

## Comparing VM sizes
_* = I only grabbed the "Cost (SEK/build)" for the potential candidates as it's time consuming to grab the info from Azure. I expect my build costs to change relative to the VM cost. `B2s` at 0.05 SEK/build means 1000 builds = 1 beer at the pub. I've done < 1400 builds in 4 months._

VM size | Cost (SEK/month) | Cost (SEK/build)* | Time to install retro-cloud on VM | Commit (with build log)
--------|------------------|------------------|-----------------------------------|------------------------
**`B2s`** | **287** | **0.05** | **4m 49s** | 37e8650
--------|---------------|--------------|-----------------------------|---------------------
`B1ls` | 36 | | +10m (timed out) | ab925fb
_`B1s`_ | _72_ | _0.02_ | _5m 54s_ | c195577
`A0` | 114 | | 17m 29s | 21a3131
`B1ms` | 144 | | 5m 43s | 3d1978e
`A1` | 159 | | 8m 26s | c293929
`A1_v2` | 261 | | 8m 45s | cfd629f
`F1` | 361 | | 5m 23s | 43572e3
_`F1s`_ | _361_ | _0.06_ | _3m 50s_ | daca76e
`D1_v2` | 419 | | 5m 19s | 5547162
`DS1_v2` | 419 | | 4m 51s | 2aed07a
`D1` | 465 | | 4m 44s | 1bfe144
`DS1` | 465 | | 4m 07s | 798f00f
`A2_v2` | 554 | | 6m 32s | 8bc579b
`B2ms` | 580 | | 3m 56s | 19c30e0
`F2s_v2` | 612 | | 4m 04s | 8870a2a

## Moving forward with `B1s` and `F1s`

Verifying commit 6e1e9b1 in branch [`min-max-azure-vm-cost`](https://github.com/seriema/retro-cloud/tree/min-max-azure-vm-cost):
- [x] user costs
- [x] CI costs
- [x] user time to create MV
- [x] CI time to create VM
- [x] user experience for `setup-vm`
- [x] user experience for `run-scraper.sh`
- [x] user experience for running EmulationStation and a game
