### PR TITLE
Simplify CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
 
     - run:
         name: Copy a freeware ROM to VM
-        command: bash -i ssh-vm.sh "curl -fL https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-copy-rom.sh | bash -i"
+        command: bash -i ssh-vm.sh 'bash -i retro-cloud-setup/dev/test-copy-rom.sh'
 
     - run:
         name: Add Screenscraper.fr credentials to VM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
 
     - run:
         name: Print Azure File Share directory listing
-        command: curl -fL "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/dev/list-az-share.ps1" | bash -i -c 'pwsh -executionpolicy bypass -Command -'
+        command: bash -i -c 'pwsh -executionpolicy bypass -File ".\retro-cloud-setup\dev\list-az-share.ps1"'
         when: always
 
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,11 +97,7 @@ jobs:
 
     - run:
         name: Print Azure File Share directory listing
-        command: |
-            curl -fOL "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/dev/list-az-share.ps1"
-            echo 'pwsh -executionpolicy bypass -File ".\list-az-share.ps1"' > run-az-listing.sh
-            bash -i run-az-listing.sh
-            rm run-az-listing.sh list-az-share.ps1
+        command: curl -fL "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/dev/list-az-share.ps1" | bash -i -c 'pwsh -executionpolicy bypass -Command -'
         when: always
 
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,7 @@ jobs:
 
     - run:
         name: Verify that ROM shows up in Azure File Share
-        command: |
-            curl -fOL "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/dev/test-az-share.ps1"
-            echo 'pwsh -executionpolicy bypass -File ".\test-az-share.ps1"' > run-az-share-test.sh
-            bash -i run-az-share-test.sh
-            rm run-az-share-test.sh test-az-share.ps1
+        command: bash -i -c 'pwsh -executionpolicy bypass -File ".\retro-cloud-setup\dev\test-az-share.ps1"'
 
     - run:
         name: Verify scraper output on VM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,7 @@ jobs:
 
     - run:
         name: Validate scripts execution permission
-        command: |
-            findFilesWithoutExecutionPermission () { find . -type f -name '*.sh' -not -executable; }
-            if [ $(findFilesWithoutExecutionPermission | wc -l) -ne 0 ]; then
-                echo 'These files are lacking execute (+x) permission:'
-                findFilesWithoutExecutionPermission
-                exit 1;
-            fi
+        command: ./shared/validate-execute-permissions.sh
 
     - run:
         name: Lint Scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,7 @@ jobs:
 
     - run:
         name: Print VM ~/.retro-cloud.env
-        command: |
-            echo 'ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP "cat ~/.retro-cloud.env"' > print-vm-bashrc.sh
-            bash -i print-vm-bashrc.sh
-            rm print-vm-bashrc.sh
+        command: bash -i ssh-vm.sh 'cat "$HOME/.retro-cloud.env"'
         when: always
 
     - run:
@@ -79,10 +76,7 @@ jobs:
 
     - run:
         name: Print VM ~/.bashrc
-        command: |
-            echo 'ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP "cat ~/.bashrc"' > print-vm-bashrc.sh
-            bash -i print-vm-bashrc.sh
-            rm print-vm-bashrc.sh
+        command: bash -i ssh-vm.sh 'cat "$HOME/.bashrc"'
         when: always
 
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
   bashValidation:
-    docker:
-    - image: koalaman/shellcheck-alpine:stable
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
 
     - checkout
@@ -13,7 +13,7 @@ jobs:
 
     - run:
         name: Lint Scripts
-        command: find . -type f -name '*.sh' | xargs shellcheck --external-sources
+        command: ./shared/lint-shellcheck.sh
 
   scriptValidation:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,16 +87,12 @@ jobs:
 
     - run:
         name: Print RaspberryPi ~/ directory listing
-        command: sudo find ~ | sed -e "s/[^-][^\/]*\// |/g" -e "s/|\([^ ]\)/|-\1/"
+        command: bash -i retro-cloud-setup/dev/list-home.sh
         when: always
 
     - run:
         name: Print VM ~/ directory listing
-        command: |
-            printCmd='sudo find ~ | sed -e "s/[^-][^\/]*\// |/g" -e "s/|\([^ ]\)/|-\1/"'
-            echo 'ssh $RETROCLOUD_VM_USER@$RETROCLOUD_VM_IP' "'$printCmd'" > print-vm-filesystem.sh
-            bash -i print-vm-filesystem.sh
-            rm print-vm-filesystem.sh
+        command: bash -i ssh-vm.sh "bash -i retro-cloud-setup/dev/list-home.sh"
         when: always
 
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,7 @@ jobs:
 
     - run:
         name: Add Screenscraper.fr credentials to VM
-        command: |
-            bash -i ssh-vm.sh "echo '' | tee -a ~/.skyscraper/config.ini"
-            bash -i ssh-vm.sh "echo '[screenscraper]' | tee -a ~/.skyscraper/config.ini"
-            bash -i ssh-vm.sh "echo 'userCreds=\"${SCREENSCRAPER_USER}:${SCREENSCRAPER_KEY}\"' | tee -a ~/.skyscraper/config.ini"
+        command: ./add-scraper-credential.sh screenscraper "$SCREENSCRAPER_USER" "$SCREENSCRAPER_KEY"
 
     - run:
         name: Run scraper on VM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,13 +51,7 @@ jobs:
 
     - run:
         name: Verify scraper output on VM
-        command: |
-            bash -i ssh-vm.sh "mkdir -p ~/tmp"
-            bash -i ssh-vm.sh "curl -fL -o ~/tmp/test-gamelist.sh https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist.sh"
-            bash -i ssh-vm.sh "curl -fL -o ~/tmp/test-gamelist.xml https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist.xml"
-            bash -i ssh-vm.sh "curl -fL -o ~/tmp/test-gamelist-screenscraper-failed.xml https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/virtual-machine/dev/test-gamelist-screenscraper-failed.xml"
-            bash -i ssh-vm.sh "bash -i ~/tmp/test-gamelist.sh"
-            bash -i ssh-vm.sh "rm ~/tmp/test-gamelist.sh ~/tmp/test-gamelist.xml ~/tmp/test-gamelist-screenscraper-failed.xml"
+        command: bash -i ssh-vm.sh "bash -i retro-cloud-setup/dev/test-gamelist.sh"
 
     - run:
         name: Print RaspberryPi ~/.retro-cloud.env

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ An expensive and over-engineered approach to storing ROMs and their metadata whi
         ```
 
     * If you have ROMs on a desktop: Use [Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/) and copy them to `Storage Accounts/[numbers]storage/Files Shares/retro-cloud/RetroPie/roms`
+1. Add scraper credentials. Retro-Cloud uses [Skyscraper by Lars Muldjord](https://github.com/muldjord/skyscraper) for scraping. It supports adding credentials the scraper modules, which can allow you to scrape using more threads, priority when the source is under heavy load, or access to sources that require credentials. Read more [here](https://github.com/muldjord/skyscraper/blob/master/docs/CONFIGINI.md#usercredscredentials-or-key). Alternatives:
+    * On the Raspberry Pi: `$ ./add-scraper-credential.sh MODULE USER PASSWORD`
+    * On the VM: `$ ./add-scraper-credential.sh MODULE USER PASSWORD`
 1. Scrape for metadata. Alternatives:
     > Note: This will take a _long_ time. A test run of 6 platforms with 13k files took 10 hours. EmulationStation must not be running during this time.
     * On the Raspberry Pi: `$ bash -i run-scraper.sh`

--- a/lint.sh
+++ b/lint.sh
@@ -4,7 +4,7 @@
 set -eu
 
 echo 'LINT: Check for Bash scripts without execute permission.'
-find . -type f -name '*.sh' -not -executable
+./shared/validate-execute-permissions.sh
 
 echo 'LINT: Lint with shellcheck.'
 # Runs shellcheck as a docker app so you don't need it installed.

--- a/lint.sh
+++ b/lint.sh
@@ -7,7 +7,6 @@ echo 'LINT: Check for Bash scripts without execute permission.'
 ./shared/validate-execute-permissions.sh
 
 echo 'LINT: Lint with shellcheck.'
-# Runs shellcheck as a docker app so you don't need it installed.
-find . -type f -name '*.sh' -print0 | xargs -0 docker run --rm --volume "$PWD:/mnt" --workdir //mnt koalaman/shellcheck:stable --external-sources
+./shared/lint-shellcheck.sh
 
 echo 'LINT: Done.'

--- a/lint.sh
+++ b/lint.sh
@@ -3,11 +3,11 @@
 # Abort on error, and error if variable is unset
 set -eu
 
-echo 'Check for Bash scripts without execute permission.'
+echo 'LINT: Check for Bash scripts without execute permission.'
 find . -type f -name '*.sh' -not -executable
 
-echo 'Lint with shellcheck.'
+echo 'LINT: Lint with shellcheck.'
 # Runs shellcheck as a docker app so you don't need it installed.
 find . -type f -name '*.sh' -print0 | xargs -0 docker run --rm --volume "$PWD:/mnt" --workdir //mnt koalaman/shellcheck:stable --external-sources
 
-echo 'Done.'
+echo 'LINT: Done.'

--- a/raspberry-pi/download-and-run.sh
+++ b/raspberry-pi/download-and-run.sh
@@ -17,6 +17,7 @@ curl -fOL "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspber
 curl -fOL "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/teardown.sh"
 curl -fOL "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/teardown-az.ps1"
 mkdir -p "local"
+curl -fL -o "local/add-scraper-credential.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/add-scraper-credential.sh"
 curl -fL -o "local/run-scraper.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/run-scraper.sh"
 curl -fL -o "local/setup-vm.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/setup-vm.sh"
 curl -fL -o "local/ssh-vm.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/ssh-vm.sh"

--- a/raspberry-pi/download-and-run.sh
+++ b/raspberry-pi/download-and-run.sh
@@ -21,6 +21,8 @@ curl -fL -o "local/add-scraper-credential.sh" "https://raw.githubusercontent.com
 curl -fL -o "local/run-scraper.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/run-scraper.sh"
 curl -fL -o "local/setup-vm.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/setup-vm.sh"
 curl -fL -o "local/ssh-vm.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/ssh-vm.sh"
+mkdir -p "dev"
+curl -fL -o "dev/test-az-share.ps1" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/test-az-share.ps1"
 
 echo "SETUP: Run setup.sh"
 bash setup.sh

--- a/raspberry-pi/download-and-run.sh
+++ b/raspberry-pi/download-and-run.sh
@@ -22,6 +22,7 @@ curl -fL -o "local/run-scraper.sh" "https://raw.githubusercontent.com/seriema/re
 curl -fL -o "local/setup-vm.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/setup-vm.sh"
 curl -fL -o "local/ssh-vm.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/ssh-vm.sh"
 mkdir -p "dev"
+curl -fL -o "dev/list-home.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/shared/list-home.sh"
 curl -fL -o "dev/test-az-share.ps1" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/test-az-share.ps1"
 
 echo "SETUP: Run setup.sh"

--- a/raspberry-pi/download-and-run.sh
+++ b/raspberry-pi/download-and-run.sh
@@ -22,6 +22,7 @@ curl -fL -o "local/run-scraper.sh" "https://raw.githubusercontent.com/seriema/re
 curl -fL -o "local/setup-vm.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/setup-vm.sh"
 curl -fL -o "local/ssh-vm.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/ssh-vm.sh"
 mkdir -p "dev"
+curl -fL -o "dev/list-az-share.ps1" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/list-az-share.ps1"
 curl -fL -o "dev/list-home.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/shared/list-home.sh"
 curl -fL -o "dev/test-az-share.ps1" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/test-az-share.ps1"
 

--- a/raspberry-pi/local/add-scraper-credential.sh
+++ b/raspberry-pi/local/add-scraper-credential.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Abort on error, and error if variable is unset
+set -eu
+
+# The VM script handles validation and to avoid duplication we just send empty strings if the user forgets an argument
+module=${1:-""}
+user=${2:-""}
+password=${3:-""}
+
+echo "Adding $module credential for $user with $password on the VM."
+
+bash -i ssh-vm.sh "./add-scraper-credential.sh $module $user $password"

--- a/raspberry-pi/setup.sh
+++ b/raspberry-pi/setup.sh
@@ -27,10 +27,12 @@ echo "SETUP: Mount remote files"
 bash -i mount-vm-share.sh
 
 echo "SETUP: Copy run scripts to user root"
+cp -v local/add-scraper-credential.sh "$HOME/add-scraper-credential.sh"
 cp -v local/run-scraper.sh "$HOME/run-scraper.sh"
 cp -v local/setup-vm.sh "$HOME/setup-vm.sh"
 cp -v local/ssh-vm.sh "$HOME/ssh-vm.sh"
 # Make them executable
+chmod +x "$HOME/add-scraper-credential.sh"
 chmod +x "$HOME/run-scraper.sh"
 chmod +x "$HOME/setup-vm.sh"
 chmod +x "$HOME/ssh-vm.sh"

--- a/shared/lint-shellcheck.sh
+++ b/shared/lint-shellcheck.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Abort on error, and error if variable is unset
+set -eu
+
+# Runs shellcheck as a docker app so you don't need it installed.
+find . -type f -name '*.sh' -print0 | xargs -0 docker run --rm --volume "$PWD:/mnt" --workdir //mnt koalaman/shellcheck:stable --external-sources

--- a/shared/list-home.sh
+++ b/shared/list-home.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Abort on error, and error if variable is unset
+set -eu
+
+sudo find "$HOME" | sed -e "s/[^-][^\/]*\// |/g" -e "s/|\([^ ]\)/|-\1/"

--- a/shared/validate-execute-permissions.sh
+++ b/shared/validate-execute-permissions.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Abort on error, and error if variable is unset
+set -eu
+
+# Turned into a function so testing can be silent but on finding files the files can be listed.
+findFilesWithoutExecutionPermission () {
+    find . -type f -name '*.sh' -not -executable;
+}
+
+if [ "$(findFilesWithoutExecutionPermission | wc -l)" -ne 0 ]; then
+    echo 'These files are lacking execute (+x) permission:'
+    findFilesWithoutExecutionPermission
+    exit 1;
+fi

--- a/virtual-machine/dev/test-gamelist.sh
+++ b/virtual-machine/dev/test-gamelist.sh
@@ -3,7 +3,7 @@
 # Abort on error, and error if variable is unset
 set -eu
 
-if diff "$RETROCLOUD_VM_SHARE/.emulationstation/gamelists/nes/gamelist.xml" ~/tmp/test-gamelist.xml
+if diff "$RETROCLOUD_VM_SHARE/.emulationstation/gamelists/nes/gamelist.xml" "$HOME/retro-cloud-setup/dev/test-gamelist.xml"
 then
     echo "Scraping was successful"
     exit 0
@@ -12,7 +12,7 @@ fi
 echo "Scraping failed somehow because the gamelist isn't as expected. See details above."
 
 echo "This could be due to Screenscraper.fr often having API issues. Trying again with a slimmer XML."
-if diff "$RETROCLOUD_VM_SHARE/.emulationstation/gamelists/nes/gamelist.xml" ~/tmp/test-gamelist-screenscraper-failed.xml
+if diff "$RETROCLOUD_VM_SHARE/.emulationstation/gamelists/nes/gamelist.xml" "$HOME/retro-cloud-setup/dev/test-gamelist-screenscraper-failed.xml"
 then
     echo "Matched. Assuming it was a fluke."
     exit 0

--- a/virtual-machine/install-skyscraper.sh
+++ b/virtual-machine/install-skyscraper.sh
@@ -29,8 +29,10 @@ sed -i -e "s+RETROCLOUD_MEDIAFOLDER+$RETROCLOUD_VM_DOWNLOADEDMEDIA+g" "$HOME/.sk
 sed -i -e "s+RETROCLOUD_CACHEFOLDER+$RETROCLOUD_VM_SKYSCRAPER_CACHE+g" "$HOME/.skyscraper/config.ini"
 
 echo 'Copy run script to user root'
+cp -v local/add-scraper-credential.sh "$HOME/add-scraper-credential.sh"
 cp -v local/run-skyscraper.sh "$HOME/run-skyscraper.sh"
 # Make it executable
+chmod 777 "$HOME/add-scraper-credential.sh"
 chmod 777 "$HOME/run-skyscraper.sh"
 
 echo 'Done!'

--- a/virtual-machine/local/add-scraper-credential.sh
+++ b/virtual-machine/local/add-scraper-credential.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Abort on error, and error if variable is unset
+set -eu
+
+if [[ $# -ne 3 || -z $1 || -z $2 || -z $3 ]]; then
+    echo
+    echo "Usage: ./add-scraper-credential.sh MODULE USER PASSWORD"
+    echo
+    echo "Adds a scraper module section to Skyscraper config"
+    echo
+    echo "    MODULE      The scraping module. Such as 'screenscraper', 'openretro', etc."
+    echo "    USER        Your username for that scraping module."
+    echo "    PASSWORD    Your password for that scraping module."
+    echo
+    echo "More info: https://github.com/muldjord/skyscraper/blob/master/docs/CONFIGINI.md#usercredscredentials-or-key"
+    echo
+    echo "Example: ./add-scraper-credential.sh screenscraper seriema secretpassword"
+    exit 2
+fi
+
+module=$1
+user=$2
+password=$3
+
+echo '' | tee -a "$HOME/.skyscraper/config.ini"
+echo "[$module]" | tee -a "$HOME/.skyscraper/config.ini"
+echo "userCreds=\"${user}:${password}\"" | tee -a "$HOME/.skyscraper/config.ini"

--- a/virtual-machine/setup.sh
+++ b/virtual-machine/setup.sh
@@ -29,6 +29,9 @@ curl -fL -o "local/run-skyscraper.sh" "https://raw.githubusercontent.com/seriema
 mkdir "dev"
 curl -fL -o "dev/list-home.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/shared/list-home.sh"
 curl -fL -o "dev/test-copy-rom.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/dev/test-copy-rom.sh"
+curl -fL -o "dev/test-gamelist-screenscraper-failed.xml" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/dev/test-gamelist-screenscraper-failed.xml"
+curl -fL -o "dev/test-gamelist.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/dev/test-gamelist.sh"
+curl -fL -o "dev/test-gamelist.xml" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/dev/test-gamelist.xml"
 
 echo "SETUP: Mount Azure File Share"
 bash mount-az-share.sh

--- a/virtual-machine/setup.sh
+++ b/virtual-machine/setup.sh
@@ -27,6 +27,7 @@ mkdir "local"
 curl -fL -o "local/add-scraper-credential.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/local/add-scraper-credential.sh"
 curl -fL -o "local/run-skyscraper.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/local/run-skyscraper.sh"
 mkdir "dev"
+curl -fL -o "dev/list-home.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/shared/list-home.sh"
 curl -fL -o "dev/test-copy-rom.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/dev/test-copy-rom.sh"
 
 echo "SETUP: Mount Azure File Share"

--- a/virtual-machine/setup.sh
+++ b/virtual-machine/setup.sh
@@ -24,6 +24,7 @@ curl -fOL "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual
 mkdir .skyscraper
 curl -fL -o ".skyscraper/config.ini" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/.skyscraper/config.ini"
 mkdir "local"
+curl -fL -o "local/add-scraper-credential.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/local/add-scraper-credential.sh"
 curl -fL -o "local/run-skyscraper.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/local/run-skyscraper.sh"
 mkdir "dev"
 curl -fL -o "dev/test-copy-rom.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/virtual-machine/dev/test-copy-rom.sh"


### PR DESCRIPTION
## Motivation
By simplifying the CircleCI config it will make two things easier:
1. Running the same steps locally
2. Changing CI provider

Regarding nr 2: I was experimenting with Travis CI the other week and it wasn't as straightforward to run inside a container. You have to run docker commands like `exec` instead of writing commands as if you were in the terminal of the container. Which made it awkward and cumbersome to translate the CircleCI config. (The reason to change is that CircleCI doesn't allow containers to run in privileged moved, which I need to mount the VM in the RPi container. Travis allows it, maybe others do too.)

## Summary

* Turn the step "Add Screenscraper.fr credentials to VM" into a feature
* Extract scripts for linting
* Include the `/dev` scripts during setup download

**Note:** I tried changing the Install on RPi to a one-liner (note the `-s --`):
```bash
curl -fL "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/download-and-run.sh" | bash -s -- "$CIRCLE_SHA1"
```
But then everything exits after a new bash shell is started in `download-and-run.sh`:
```bash
echo "SETUP: Run setup.sh"
bash setup.sh # <- The build exits after this

echo "SETUP: Done!" # <- The build doesn't reach this point
``` 

**Note:** The failed build in 2a8f507 is just the call to a lint script with `./` that doesn't work in the shellcheck docker image. That image is replaced with a regular Ubuntu one in the commit after (8ee7fd2), which also fixes the call. It's not worth the time and costs to rebase and run 10 new builds.

> _This PR is just for convenience in the future to see what had to change in the scripts to support the merged feature._