### PR TITLE
Simplify CircleCI config further

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,51 +46,12 @@ jobs:
         command: bash -i run-scraper.sh
 
     - run:
-        name: Verify that ROM shows up in Azure File Share
-        command: bash -i -c 'pwsh -executionpolicy bypass -File ".\retro-cloud-setup\dev\test-az-share.ps1"'
+        name: Test all environments
+        command: bash -i retro-cloud-setup/dev/run-tests.sh
 
     - run:
-        name: Verify scraper output on VM
-        command: bash -i ssh-vm.sh "bash -i retro-cloud-setup/dev/test-gamelist.sh"
-
-    - run:
-        name: Print RaspberryPi ~/.retro-cloud.env
-        command: cat ~/.retro-cloud.env
-        when: always
-
-    - run:
-        name: Print VM ~/.retro-cloud.env
-        command: bash -i ssh-vm.sh 'cat "$HOME/.retro-cloud.env"'
-        when: always
-
-    - run:
-        name: Print RaspberryPi ~/.bashrc
-        command: cat ~/.bashrc
-        when: always
-
-    - run:
-        name: Print VM ~/.bashrc
-        command: bash -i ssh-vm.sh 'cat "$HOME/.bashrc"'
-        when: always
-
-    - run:
-        name: Print RaspberryPi ~/ directory listing
-        command: bash -i retro-cloud-setup/dev/list-home.sh
-        when: always
-
-    - run:
-        name: Print VM ~/ directory listing
-        command: bash -i ssh-vm.sh "bash -i retro-cloud-setup/dev/list-home.sh"
-        when: always
-
-    - run:
-        name: Print Azure File Share directory listing
-        command: bash -i -c 'pwsh -executionpolicy bypass -File ".\retro-cloud-setup\dev\list-az-share.ps1"'
-        when: always
-
-    - run:
-        name: Print VM Skyscraper config
-        command: bash -i ssh-vm.sh "cat ~/.skyscraper/config.ini"
+        name: Print all environments
+        command: bash -i retro-cloud-setup/dev/print-all.sh
         when: always
 
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
         name: Install Retro-Cloud on RaspberryPi (Setup Azure resources)
         command: |
             curl -fOL "https://raw.githubusercontent.com/seriema/retro-cloud/${CIRCLE_SHA1}/raspberry-pi/download-and-run.sh"
-            bash download-and-run.sh $CIRCLE_SHA1
+            bash download-and-run.sh "$CIRCLE_SHA1" "CircleCI-$CIRCLE_BUILD_NUM"
             rm download-and-run.sh
 
     - run:
@@ -56,7 +56,7 @@ jobs:
 
     - run:
         name: Teardown Azure resources
-        command: cd retro-cloud-setup && bash teardown.sh
+        command: cd retro-cloud-setup && bash teardown.sh "CircleCI-$CIRCLE_BUILD_NUM"
         when: always
 
   imageValidation:

--- a/raspberry-pi/create-vm.ps1
+++ b/raspberry-pi/create-vm.ps1
@@ -1,3 +1,9 @@
+# Take a parameter for prefixing the resource group name. It default to the current date to be unique
+# yet findable. Useful values could be the build number during CI, or the users unique machine name.
+param (
+    [string]$rgPrefix = [NullString]::Value
+)
+
 # https://docs.microsoft.com/en-us/azure/virtual-machines/linux/quick-create-powershell
 
 # Abort on error
@@ -26,8 +32,11 @@ function ProgressHelper {
 }
 
 # Shared variables
-$prefix = Get-Date -Format "yyyy-MM-dd__HH.mm.ss__"
-$rg = "$($prefix)retro-cloud"
+# If no prefix was passed as a parameter to the script, default to the current date.
+if ([String]::IsNullOrEmpty($rgPrefix)) {
+    $rgPrefix = Get-Date -Format "yyyy-MM-dd__HH.mm.ss__"
+}
+$rg = "$($rgPrefix)__retro-cloud"
 $loc = "EastUS"
 $envVarFile="$HOME/.retro-cloud.env"
 
@@ -139,7 +148,7 @@ $nic | Format-Table
 $currentActivity = "Create the storage account (for scraping cache and boot diagnostics)"
 
 # Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only.
-$storageAccountName = ("$($prefix)storage" -replace '[^A-Za-z0-9]+', '').ToLower()
+$storageAccountName = ("$($rgPrefix)storage" -replace '[^A-Za-z0-9]+', '').ToLower()
 
 ProgressHelper $currentActivity "Creating the storage account"
 $storageAccount = New-AzStorageAccount `

--- a/raspberry-pi/dev/print-all.sh
+++ b/raspberry-pi/dev/print-all.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Abort on error, error if variable is unset, and error if any pipeline element fails
+set -euo pipefail
+
+echo
+echo '###############################################################################'
+echo '##########  Raspberry Pi  #####################################################'
+
+echo
+echo 'PRINT: RaspberryPi ~/.retro-cloud.env  ########################################'
+cat "$HOME/.retro-cloud.env"
+
+echo
+echo 'PRINT: RaspberryPi ~/.bashrc  #################################################'
+cat "$HOME/.bashrc"
+
+echo
+echo 'PRINT: RaspberryPi ~/ directory listing  ######################################'
+bash -i retro-cloud-setup/dev/list-home.sh
+
+echo
+echo '###############################################################################'
+echo '##########  File Share  #######################################################'
+
+echo
+echo 'PRINT: Azure File Share directory listing'
+pwsh -executionpolicy bypass -File "./retro-cloud-setup/dev/list-az-share.ps1"
+
+echo
+echo '###############################################################################'
+echo '##########  VM  ###############################################################'
+
+echo
+echo 'PRINT: VM ~/.retro-cloud.env  #################################################'
+# shellcheck disable=SC2016
+./ssh-vm.sh 'cat "$HOME/.retro-cloud.env"'
+
+echo
+echo 'PRINT: VM ~/.bashrc  ##########################################################'
+# shellcheck disable=SC2016
+./ssh-vm.sh 'cat "$HOME/.bashrc"'
+
+echo
+echo 'PRINT: VM ~/ directory listing  ###############################################'
+./ssh-vm.sh 'bash -i retro-cloud-setup/dev/list-home.sh'
+
+echo
+echo 'PRINT: VM Skyscraper config  ##################################################'
+./ssh-vm.sh 'cat ~/.skyscraper/config.ini'
+
+#
+# End
+
+echo
+echo '###############################################################################'
+echo 'PRINT: Done.'
+echo

--- a/raspberry-pi/dev/print-all.sh
+++ b/raspberry-pi/dev/print-all.sh
@@ -1,58 +1,69 @@
 #!/bin/bash
 
-# Abort on error, error if variable is unset, and error if any pipeline element fails
-set -euo pipefail
+# Do not stop on error, because these prints are to help debug when any setup or test steps fail. The error is piped to an error handler instead of aborting.
+# Example: Printing .retro-cloud.env on the VM might fail because it's missing, but it's still valuable to see all the other prints.
+# Abort on error, and error if variable is unset
+set -eu
+
+exitCode=0
+print_fail() {
+    exitCode=$?
+    echo -en '\e[40;31mPRINT: Failed! The script will continue as there might be a print with a clue.  ##############################################################################'
+    echo
+}
 
 echo
-echo '###############################################################################'
-echo '##########  Raspberry Pi  #####################################################'
+echo '##############################################################################################################################################################'
+echo '##########  Raspberry Pi  ####################################################################################################################################'
 
 echo
-echo 'PRINT: RaspberryPi ~/.retro-cloud.env  ########################################'
-cat "$HOME/.retro-cloud.env"
+echo 'PRINT: RaspberryPi ~/.retro-cloud.env  #######################################################################################################################'
+cat "$HOME/.retro-cloud.env" || print_fail
 
 echo
-echo 'PRINT: RaspberryPi ~/.bashrc  #################################################'
-cat "$HOME/.bashrc"
+echo 'PRINT: RaspberryPi ~/.bashrc  ################################################################################################################################'
+cat "$HOME/.bashrc" || print_fail
 
 echo
-echo 'PRINT: RaspberryPi ~/ directory listing  ######################################'
-bash -i retro-cloud-setup/dev/list-home.sh
+echo 'PRINT: RaspberryPi ~/ directory listing  #####################################################################################################################'
+bash -i retro-cloud-setup/dev/list-home.sh || print_fail
 
 echo
-echo '###############################################################################'
-echo '##########  File Share  #######################################################'
+echo '##############################################################################################################################################################'
+echo '##########  File Share  ######################################################################################################################################'
 
 echo
 echo 'PRINT: Azure File Share directory listing'
-pwsh -executionpolicy bypass -File "./retro-cloud-setup/dev/list-az-share.ps1"
+pwsh -executionpolicy bypass -File "./retro-cloud-setup/dev/list-az-share.ps1" || print_fail
 
 echo
-echo '###############################################################################'
-echo '##########  VM  ###############################################################'
+echo '##############################################################################################################################################################'
+echo '##########  VM  ##############################################################################################################################################'
 
 echo
-echo 'PRINT: VM ~/.retro-cloud.env  #################################################'
+echo 'PRINT: VM ~/.retro-cloud.env  ################################################################################################################################'
 # shellcheck disable=SC2016
-./ssh-vm.sh 'cat "$HOME/.retro-cloud.env"'
+./ssh-vm.sh 'cat "$HOME/.retro-cloud.env"' || print_fail
 
 echo
-echo 'PRINT: VM ~/.bashrc  ##########################################################'
+echo 'PRINT: VM ~/.bashrc  #########################################################################################################################################'
 # shellcheck disable=SC2016
-./ssh-vm.sh 'cat "$HOME/.bashrc"'
+./ssh-vm.sh 'cat "$HOME/.bashrc"' || print_fail
 
 echo
-echo 'PRINT: VM ~/ directory listing  ###############################################'
-./ssh-vm.sh 'bash -i retro-cloud-setup/dev/list-home.sh'
+echo 'PRINT: VM ~/ directory listing  ##############################################################################################################################'
+./ssh-vm.sh 'bash -i retro-cloud-setup/dev/list-home.sh' || print_fail
 
 echo
-echo 'PRINT: VM Skyscraper config  ##################################################'
-./ssh-vm.sh 'cat ~/.skyscraper/config.ini'
+echo 'PRINT: VM Skyscraper config  #################################################################################################################################'
+./ssh-vm.sh 'cat ~/.skyscraper/config.ini' || print_fail
 
 #
 # End
 
 echo
-echo '###############################################################################'
+echo '##############################################################################################################################################################'
 echo 'PRINT: Done.'
 echo
+
+exit $exitCode

--- a/raspberry-pi/dev/run-tests.sh
+++ b/raspberry-pi/dev/run-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Abort on error, error if variable is unset, and error if any pipeline element fails
+set -euo pipefail
+
+echo "TEST: Verify that ROM shows up in Azure File Share"
+pwsh -executionpolicy bypass -File './retro-cloud-setup/dev/test-az-share.ps1'
+
+echo "TEST: Verify scraper output on VM"
+bash -i ssh-vm.sh 'bash -i retro-cloud-setup/dev/test-gamelist.sh'
+
+echo "TEST: Done"

--- a/raspberry-pi/download-and-run.sh
+++ b/raspberry-pi/download-and-run.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
-# Script takes optional parameter for branch name or commit hash.
+# Script takes optional parameters:
+# 1: Branch name or commit hash. Useful for getting any development branch and still test as the user.
+# 2: The prefix to use for the resource group in Azure. It default to the current date to be unique
+#     yet findable. Useful values could be the build number during CI, or the users unique machine name.
 branch=${1:-master}
+rgPrefix=${2:-''}
 
 # Abort on error, error if variable is unset, and error if any pipeline element fails
 set -euo pipefail
@@ -29,6 +33,6 @@ curl -fL -o "dev/run-tests.sh" "https://raw.githubusercontent.com/seriema/retro-
 curl -fL -o "dev/test-az-share.ps1" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/test-az-share.ps1"
 
 echo "SETUP: Run setup.sh"
-bash setup.sh
+bash setup.sh "$rgPrefix"
 
 echo "SETUP: Done!"

--- a/raspberry-pi/download-and-run.sh
+++ b/raspberry-pi/download-and-run.sh
@@ -23,6 +23,7 @@ curl -fL -o "local/setup-vm.sh" "https://raw.githubusercontent.com/seriema/retro
 curl -fL -o "local/ssh-vm.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/local/ssh-vm.sh"
 mkdir -p "dev"
 curl -fL -o "dev/list-az-share.ps1" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/list-az-share.ps1"
+curl -fL -o "dev/print-all.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/print-all.sh"
 curl -fL -o "dev/list-home.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/shared/list-home.sh"
 curl -fL -o "dev/test-az-share.ps1" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/test-az-share.ps1"
 

--- a/raspberry-pi/download-and-run.sh
+++ b/raspberry-pi/download-and-run.sh
@@ -25,6 +25,7 @@ mkdir -p "dev"
 curl -fL -o "dev/list-az-share.ps1" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/list-az-share.ps1"
 curl -fL -o "dev/print-all.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/print-all.sh"
 curl -fL -o "dev/list-home.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/shared/list-home.sh"
+curl -fL -o "dev/run-tests.sh" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/run-tests.sh"
 curl -fL -o "dev/test-az-share.ps1" "https://raw.githubusercontent.com/seriema/retro-cloud/$branch/raspberry-pi/dev/test-az-share.ps1"
 
 echo "SETUP: Run setup.sh"

--- a/raspberry-pi/setup-az.ps1
+++ b/raspberry-pi/setup-az.ps1
@@ -1,6 +1,12 @@
+# Take a parameter for prefixing the Azure resource group name. It default to the current date to be unique
+# yet findable. Useful values could be the build number during CI, or the users unique machine name.
+param (
+    [string]$rgPrefix = [NullString]::Value
+)
+
 # Abort on error
 $ErrorActionPreference = "Stop"
 
 ./install-az-module.ps1
 
-./create-vm.ps1
+./create-vm.ps1 $rgPrefix

--- a/raspberry-pi/setup.sh
+++ b/raspberry-pi/setup.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Take a parameter for prefixing the Azure resource group name. It default to the current date to be unique
+# yet findable. Useful values could be the build number during CI, or the users unique machine name.
+rgPrefix=${1:-''}
 
 # Abort on error, error if variable is unset, and error if any pipeline element fails
 set -euo pipefail
@@ -19,7 +22,7 @@ echo "SETUP: Install PowerShell"
 bash install-ps.sh
 
 echo "SETUP: Run PowerShell scripts to create the Azure resources"
-pwsh -executionpolicy bypass -File ".\setup-az.ps1"
+pwsh -executionpolicy bypass -File ".\setup-az.ps1" -rgPrefix "$rgPrefix"
 
 echo "SETUP: Mount remote files"
 # Run this in interactive mode, otherwise bash won't load the variables set in ~/.bashrc by the create-vm-share.sh script above.

--- a/raspberry-pi/teardown-az.ps1
+++ b/raspberry-pi/teardown-az.ps1
@@ -1,3 +1,11 @@
+# Take a parameter for prefixing the Azure resource group name. This is useful when you want to
+# destroy a resource group that was created outside of the scripts during development, or in CI
+# when the resource group prefix is predictable and the teardown can happen in a context (such as a
+# separate container) without '.retro-cloud.env' available.
+param (
+    [string]$rgPrefix = [NullString]::Value
+)
+
 # Can run without prompting if the following environment variables are set:
 # * AZURE_SERVICE_PRINCIPAL_SECRET
 
@@ -7,7 +15,16 @@ $ErrorActionPreference = "Stop"
 # Enable debug output
 $DebugPreference = "Continue"
 
-'Delete resources from Azure ...'
+# If no parameter was given, use what should be available during a normal installation.
+if ([String]::IsNullOrEmpty($rgPrefix)) {
+    $resourceGroup = $env:RETROCLOUD_AZ_RESOURCE_GROUP
+}
+# When a parameter is given, use the same naming convention as create-vm.ps1
+else {
+    $resourceGroup = "$($rgPrefix)__retro-cloud"
+}
+
+"Delete Azure resource group $resourceGroup ..."
 if (!$env:AZURE_SERVICE_PRINCIPAL_SECRET) {
     '... Note: This operation takes a very long time (15-20 min) so it will only send a command to Azure and not wait for the removal to be complete.'
 
@@ -16,11 +33,11 @@ if (!$env:AZURE_SERVICE_PRINCIPAL_SECRET) {
     $choices  = '&Yes', '&No'
     $decision = $Host.UI.PromptForChoice($title, $question, $choices, 1)
     if ($decision -eq 0) {
-        Remove-AzResourceGroup -Name $env:RETROCLOUD_AZ_RESOURCE_GROUP -AsJob
+        Remove-AzResourceGroup -Name $resourceGroup -AsJob
     } else {
         Write-Host 'Cancelled.'
     }
 } else {
     '... assuming automation with Service Principle. Do not wait for resources to be deleted.'
-    Remove-AzResourceGroup -Name $env:RETROCLOUD_AZ_RESOURCE_GROUP -Force -AsJob
+    Remove-AzResourceGroup -Name $resourceGroup -Force -AsJob
 }

--- a/raspberry-pi/teardown.sh
+++ b/raspberry-pi/teardown.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Take a parameter for prefixing the Azure resource group name. This is useful when you want to
+# destroy a resource group that was created outside of the scripts during development, or in CI
+# when the resource group prefix is predictable and the teardown can happen in a context (such as a
+# separate container) without '.retro-cloud.env' available.
+rgPrefix=${1:-''}
 
 # Abort on error, error if variable is unset, and error if any pipeline element fails
 set -euo pipefail
@@ -8,6 +13,6 @@ set -euo pipefail
 source "$HOME/.retro-cloud.env"
 
 echo "TEARDOWN: Run PowerShell scripts to remove the Azure resources"
-pwsh -executionpolicy bypass -File ".\teardown-az.ps1"
+pwsh -executionpolicy bypass -File ".\teardown-az.ps1" -resourceGroup "$rgPrefix"
 
 echo "TEARDOWN: Done!"


### PR DESCRIPTION
## Motivation
This is a continuation of PR #18 to make it easier to:
1. Run the same steps locally
2. Change CI provider

And also:
* Identify resource groups in Azure with the build number
* Prepare for persistent Azure environments, that are created from the master branch and would allow me to use Retro-Cloud as a user that's always on the latest version

This came from experimenting with Travis and needing to differentiate between the resource groups as both CI's were using time stamps. It's also a feature I've wanted for a while because I imagine users wanting a simper resource group, yet needing a unique Azure Storage URL.

## Summary

* Test both RPi and VM from one script running on the RPi
* Print the RPi's and VM's: `.bashrc`, `.retro-cloud.dev` (env vars), and directory listings. Also prints the Azure File Share listing.
	* Note: The Azure script is getting outdated:
	```
	WARNING: Breaking changes in the cmdlet 'Get-AzStorageFile' :
	WARNING:  - "The output type 'Microsoft.Azure.Storage.File.CloudFile' is changing"
	WARNING: 	Change description : The output type will change from CloudFile to AzureStorageFile, and AzureStorageFile will have CloudFile as a child property.
	WARNING: NOTE : Go to https://aka.ms/azps-changewarnings for steps to suppress this breaking change warning, and other information on breaking changes in Azure PowerShell.
	```
* Take an optional parameter when running `download-and-run.sh`, `setup.sh`, and `teardown.sh`. It replaces the default timestamp that's used for resources in Azure.
	* CircleCI resource groups now use `"CircleCI-$CIRCLE_BUILD_NUM`", e.g. `"CircleCI-1721__retro-cloud"`.

> _This PR is just for convenience in the future to see what had to change in the scripts to support the merged feature._